### PR TITLE
Protect FacebookGrant from "confused deputy" problem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
         "bshaffer/oauth2-server-php": "^1.8"
     },
     "require-dev": {
-        "doctrine/doctrine-orm-module": "^0.11",
-        "facebook/php-sdk-v4": "^5.1",
+        "doctrine/doctrine-orm-module": "^1.0",
+        "facebook/graph-sdk": "^5.3.1",
         "guzzlehttp/guzzle": "^6.1",
         "phpunit/phpunit": "^4.8",
         "scrutinizer/ocular": "~1.1",

--- a/src/OAuth2/GrantType/Facebook.php
+++ b/src/OAuth2/GrantType/Facebook.php
@@ -54,6 +54,12 @@ class Facebook extends AbstractSocialGrantType
                 return null;
             }
 
+            // do not accept tokens generated not for our application even if they are valid,
+            // to protect against "man in the middle" attack
+            $tokenMetadata = $this->facebook->getOAuth2Client()->debugToken($token);
+            // this is not required, but lets be sure because facebook API changes very often
+            $tokenMetadata->validateAppId($this->facebook->getApp()->getId());
+
             $userProfile = new UserProfile();
             $userProfile->setIdentifier($user->getId());
             $userProfile->setDisplayName($user->getName());


### PR DESCRIPTION
Before it was possible to use tokens generated for other applications. Also updated facebook SDK dependancy.
