### PR TITLE
Calling Doctrine\ORM\EntityManager::flush() with any arguments to flu…

### DIFF
--- a/src/Storage/Doctrine.php
+++ b/src/Storage/Doctrine.php
@@ -73,7 +73,7 @@ class Doctrine implements SocialUserStorageInterface
         $socialUser->setProvider($provider);
 
         $this->em->persist($socialUser);
-        $this->em->flush($socialUser);
+        $this->em->flush();
 
         return $socialUser;
     }

--- a/tests/SocialUserTest/Storage/DoctrineTest.php
+++ b/tests/SocialUserTest/Storage/DoctrineTest.php
@@ -2,7 +2,7 @@
 
 namespace Svycka\SocialUserTest\Storage;
 
-use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Persistence\ObjectRepository;
 use Doctrine\ORM\EntityManager;
 use Prophecy\Argument\Token\TypeToken;
 use Svycka\SocialUser\Entity\SocialUser;
@@ -69,7 +69,7 @@ class DoctrineTest extends \PHPUnit\Framework\TestCase
     public function testCanAddSocialUserLogin()
     {
         $this->entityManager->persist(new TypeToken(SocialUserInterface::class))->shouldBeCalled();
-        $this->entityManager->flush(new TypeToken(SocialUserInterface::class))->shouldBeCalled();
+        $this->entityManager->flush()->shouldBeCalled();
 
         $storage = new Doctrine($this->entityManager->reveal());
         $login = $storage->addSocialUser(1, 'id', 'provider');


### PR DESCRIPTION
…sh specific entities is deprecated and will not be supported in Doctrine ORM 3.0.

fixes #12 